### PR TITLE
Add element invisible styling

### DIFF
--- a/www/templates/osm/css/custom.css
+++ b/www/templates/osm/css/custom.css
@@ -86,3 +86,14 @@ div.mod_search63 input[type="search"]{
 
 
 /* End of Cookie Control */
+
+/* A11y */
+.element-invisible {
+	position: absolute;
+	padding: 0;
+	margin: 0;
+	border: 0;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+}


### PR DESCRIPTION
Missing styling for the label element in the search area. Once this is merged the label for the search module should be added in the module settings for a11y purposes